### PR TITLE
Fixed for Godot TileSet generation creates Autotile Bitmask tiles outside of region

### DIFF
--- a/resources/templates/tileset.tres
+++ b/resources/templates/tileset.tres
@@ -194,10 +194,7 @@ Vector2( 9, 1 ), 254,
 Vector2( 9, 2 ), 442,
 Vector2( 9, 3 ), 190,
 Vector2( 10, 2 ), 250,
-Vector2( 10, 3 ), 187,
-Vector2( 11, 0 ), 442,
-Vector2( 11, 1 ), 443,
-Vector2( 11, 2 ), 154 ]
+Vector2( 10, 3 ), 187]
 1/autotile/icon_coordinate = Vector2( 3, 3 )
 1/autotile/tile_size = Vector2( $TS, $TS )
 1/autotile/spacing = 0


### PR DESCRIPTION
I found an issue that after generating a Godot autotile with autotiler there are extra tiles outside of the TileSet region with a bitmask as you can see in the image below. I encountered this issue firsthand after using this tool to save time creating TileSets and ran into the weird bug where occasionally some of my tiles were invisible and did some digging into Godot and then the TileSet's bitmask itself and found it. 

![Autotiler bug](https://user-images.githubusercontent.com/34784335/132606546-f645a4b4-8985-401d-9d84-5ea57764231e.PNG)

Digging into the .tres files it looks like its the 3 last generated bitmasks that are the problem, specifically in the tileset.tres the lines:

Vector2( 11, 0 ), 442,
Vector2( 11, 1 ), 443,
Vector2( 11, 2 ), 154 

Looking above you can see the same bitmasks 442, 443, and 154 used earlier and can spot them on the image of the bitmasks.
After removing these from my local copy of the repo and re-exporting to Godot the issue was fixed.